### PR TITLE
xUnit Test Runner and Hudson

### DIFF
--- a/lib/albacore/xunittestrunner.rb
+++ b/lib/albacore/xunittestrunner.rb
@@ -46,6 +46,6 @@ class XUnitTestRunner
 
   def build_html_output			
     fail_with_message 'Directory is required for html_output' if !File.directory?(File.expand_path(@html_output))
-    "/html #{File.join(File.expand_path(@html_output),"%s.html")}" 	
+    "/html \"#{File.join(File.expand_path(@html_output),"%s.html")}\"" 	
   end
 end


### PR DESCRIPTION
This is a bug fix for http://github.com/derickbailey/Albacore/issues/issue/109

seems like xunit and hudson test runner doen't go well if the path has a space.

i edited both the master and dev branch

details in the issue.
