### PR TITLE
Add version to msbuild to switch .net framework

### DIFF
--- a/lib/albacore/msbuild.rb
+++ b/lib/albacore/msbuild.rb
@@ -6,12 +6,13 @@ class MSBuild
   include YAMLConfig
   include Logging
   
-  attr_accessor :solution, :verbosity
+  attr_accessor :solution, :verbosity, :version
   attr_array :targets
   attr_hash :properties
   
   def initialize
     @path_to_command = build_path_to_command
+    self.version = "v3.5"
     super()
   end
   
@@ -19,10 +20,11 @@ class MSBuild
     win_dir = ENV['windir'] || ENV['WINDIR']
     win_dir = 'C:/Windows' if win_dir.nil?
     
-    File.join(win_dir.dup, 'Microsoft.NET', 'Framework', 'v3.5', 'MSBuild.exe')
+    File.join(win_dir.dup, 'Microsoft.NET', 'Framework', self.version, 'MSBuild.exe')
   end
   
   def build
+    @path_to_command = build_path_to_command
     build_solution(@solution)
   end
   

--- a/lib/albacore/msbuild.rb
+++ b/lib/albacore/msbuild.rb
@@ -11,8 +11,8 @@ class MSBuild
   attr_hash :properties
   
   def initialize
-    @path_to_command = build_path_to_command
     self.version = "v3.5"
+    @path_to_command = build_path_to_command
     super()
   end
   

--- a/rakefile.rb
+++ b/rakefile.rb
@@ -1,4 +1,4 @@
-require 'lib/albacore'
+require './lib/albacore'
 
 task :default => ['albacore:sample']
 


### PR DESCRIPTION
Now albacore is hardcoded to use .net 3.5. I have added a property version to change the version of .net framework, which is just simply using folder name of framework, like "v4.0.30319"

Thanks 
Jackson Zhang
