### PR TITLE
adding an 'output' task.

### DIFF
--- a/lib/albacore/output.rb
+++ b/lib/albacore/output.rb
@@ -1,36 +1,55 @@
 require 'albacore/albacoretask'
-
+require 'erb'
+require 'ostruct'
 
 class OutputBuilder
-    include FileUtils
+  include FileUtils
+  
+  def initialize(dir_to, dir_from)
+    @dir_to = dir_to
+    @dir_from = dir_from
+  end
+  
+  def dir(dir)
+    cp_r "#{@dir_from}/#{dir}", @dir_to
+  end
+  
+  def file(f)
+    file(f,f)
+  end
     
-    def initialize(dir_to, dir_from)
-        @dir_to = dir_to
-        @dir_from = dir_from
-    end
-    
-    def dir(dir)
-        cp_r "#{@dir_from}/#{dir}", @dir_to
-    end
-    
-    def file(f)
-        file(f,f)
-    end
-    
-    def file(f, ft)
+  def file(f, ft)
     #todo find more elegant way to create base dir if missing for file.
-        topath = File.dirname("#{@dir_to}/#{ft}")
-        mkdir_p topath unless File.exist? topath
-        cp "#{@dir_from}/#{f}", "#{@dir_to}/#{ft}"
-    end
-    
-    def self.output_to(dir_to, dir_from)
-        rmtree dir_to
-        mkdir dir_to
-        yield OutputBuilder.new(dir_to, dir_from)
-    end
-
+    initialize_to_path(ft)
+    cp "#{@dir_from}/#{f}", "#{@dir_to}/#{ft}"
+  end
+  
+  def erb(f, ft, locals)
+    initialize_to_path(ft)
+    erb = ERB.new(File.read("#{@dir_from}/#{f}"))
+    File.open("#{@dir_to}/#{ft}", 'w') {|f| f.write erb.result(ErbBinding.new(locals).get_binding)}
+  end
+  
+  def self.output_to(dir_to, dir_from)
+    rmtree dir_to
+    mkdir dir_to
+    yield OutputBuilder.new(dir_to, dir_from)
+  end
+  
+private
+  def initialize_to_path(ft)
+    topath = File.dirname("#{@dir_to}/#{ft}")
+    mkdir_p topath unless File.exist? topath
+    topath
+  end
 end
+
+class ErbBinding < OpenStruct
+  def get_binding
+    return binding()
+  end
+end
+  
 
 class Output
   include Albacore::Task
@@ -39,6 +58,7 @@ class Output
     super()
     
     @files = []
+    @erbs = []
     @directories = []
   end
     
@@ -48,7 +68,8 @@ class Output
     
     OutputBuilder.output_to(@to_dir, @from_dir)  do |o|
         @directories.each { |f| o.dir f }
-        @files.each { |f| o.file f[0], f[1] }
+        @files.each { |f| o.file *f }
+        @erbs.each { |f| o.erb *f }
     end
   end
   
@@ -57,6 +78,10 @@ class Output
     @files << [f,f_to]
   end
 
+  def erb(f, opts={})
+    f_to = opts[:as] || f
+    @erbs << [f,f_to,opts[:locals]||{}]
+  end
   
   def dir(d)
     @directories << d

--- a/lib/albacore/output.rb
+++ b/lib/albacore/output.rb
@@ -1,0 +1,73 @@
+require 'albacore/albacoretask'
+
+
+class OutputBuilder
+    include FileUtils
+    
+    def initialize(dir_to, dir_from)
+        @dir_to = dir_to
+        @dir_from = dir_from
+    end
+    
+    def dir(dir)
+        cp_r "#{@dir_from}/#{dir}", @dir_to
+    end
+    
+    def file(f)
+        file(f,f)
+    end
+    
+    def file(f, ft)
+    #todo find more elegant way to create base dir if missing for file.
+        topath = File.dirname("#{@dir_to}/#{ft}")
+        mkdir_p topath unless File.exist? topath
+        cp "#{@dir_from}/#{f}", "#{@dir_to}/#{ft}"
+    end
+    
+    def self.output_to(dir_to, dir_from)
+        rmtree dir_to
+        mkdir dir_to
+        yield OutputBuilder.new(dir_to, dir_from)
+    end
+
+end
+
+class Output
+  include Albacore::Task
+
+  def initialize
+    super()
+    
+    @files = []
+    @directories = []
+  end
+    
+  def execute()
+    fail_with_message 'No base dir' if @from_dir.nil?
+    fail_with_message 'No output dir' if @to_dir.nil?
+    
+    OutputBuilder.output_to(@to_dir, @from_dir)  do |o|
+        @directories.each { |f| o.dir f }
+        @files.each { |f| o.file f[0], f[1] }
+    end
+  end
+  
+  def file(f, opts={})
+    f_to = opts[:as] || f
+    @files << [f,f_to]
+  end
+
+  
+  def dir(d)
+    @directories << d
+  end
+  
+  def from(from_dir)
+    @from_dir = from_dir
+  end
+
+  def to(to_dir)
+    @to_dir = to_dir
+  end
+  
+end

--- a/rakefile.rb
+++ b/rakefile.rb
@@ -107,6 +107,13 @@ namespace :specs do
     t.spec_files = FileList['spec/yaml*_spec.rb']
     t.spec_opts << @spec_opts
   end
+  
+  desc "Output functional specs"
+  Spec::Rake::SpecTask.new :output do |t|
+    t.spec_files = FileList['spec/output*_spec.rb']
+    t.spec_opts << @spec_opts
+  end
+    
 end
 
 namespace :albacore do  

--- a/spec/output_spec.rb
+++ b/spec/output_spec.rb
@@ -111,6 +111,7 @@ describe Output, 'when having a from and to set' do
         
         File.exist?("#{OutputTestData.to}/subdir/foo").should be_true
         File.exist?("#{OutputTestData.to}/subdir/foo/web.config").should be_true
+        File.read("#{OutputTestData.to}/subdir/foo/web.config").should == "test_sub hello"
       end
     end
 end

--- a/spec/output_spec.rb
+++ b/spec/output_spec.rb
@@ -1,0 +1,100 @@
+require 'spec_helper'
+require 'outputtestdata'
+describe Output, 'when having a from and to set' do 
+
+      before :each do
+        FileUtils.mkdir(OutputTestData.from) unless File.exists? OutputTestData.from
+        
+        @o = Output.new
+        @o.from OutputTestData.from
+        @o.to OutputTestData.to
+        
+      end
+      after :each do
+        FileUtils.rm_rf OutputTestData.to if File.exists? OutputTestData.to
+        FileUtils.rm_rf OutputTestData.from if File.exists? OutputTestData.from
+      end
+  
+  
+    describe 'and when outputting files' do
+      before :each do
+        File.open("#{OutputTestData.from}/test.txt", "w"){|f| f.write "test" }
+      end
+      
+      it "should not output a file if not specified so" do
+        @o.execute
+       
+        File.exist?("#{OutputTestData.to}/test.txt").should be_false
+      end
+      
+      it "should output a file specified" do
+        @o.file 'test.txt'
+        @o.execute
+       
+        File.exist?("#{OutputTestData.to}/test.txt").should be_true
+      end
+    end
+    
+    
+    describe 'and when outputting directories' do
+      before :each do
+        subdir = "#{OutputTestData.from}/subdir"
+        FileUtils.mkdir(subdir) unless File.exists? subdir
+        File.open("#{OutputTestData.from}/subdir/test.txt", "w"){|f| f.write "test_sub" }
+      end
+      
+      it "should not output a directory if not specified so" do
+        @o.execute
+       
+        File.exist?("#{OutputTestData.to}/subdir").should be_false
+      end
+      
+      it "should output a directory and content if specified" do
+        @o.dir 'subdir'
+        @o.execute
+       
+        File.exist?("#{OutputTestData.to}/subdir").should be_true
+        File.exist?("#{OutputTestData.to}/subdir/test.txt").should be_true
+      end
+    end
+    
+    describe 'and when outputting nested directories' do
+      before :each do
+        subdir = "#{OutputTestData.from}/subdir/foo"
+        FileUtils.mkdir_p(subdir) unless File.exists? subdir
+        File.open("#{OutputTestData.from}/subdir/foo/test.txt", "w"){|f| f.write "test_sub" }
+      end
+      
+      it "should not output a directory if not specified so" do
+        @o.execute
+       
+        File.exist?("#{OutputTestData.to}/subdir/foo").should be_false
+      end
+      
+      it "should output a directory and content if specified" do
+        @o.dir 'subdir'
+        @o.execute
+       
+        File.exist?("#{OutputTestData.to}/subdir/foo").should be_true
+        File.exist?("#{OutputTestData.to}/subdir/foo/test.txt").should be_true
+      end
+    end
+    
+    
+    describe 'and when outputting files with renaming them at target' do
+      before :each do
+        subdir = "#{OutputTestData.from}/subdir/foo"
+        FileUtils.mkdir_p(subdir) unless File.exists? subdir
+        File.open("#{OutputTestData.from}/subdir/foo/test.txt", "w"){|f| f.write "test_sub" }
+      end
+      
+      it "should rename and create entire path if nested deeply" do
+        @o.file 'subdir/foo/test.txt', :as => 'subdir/foo/hello.txt'
+        @o.execute
+       
+        File.exist?("#{OutputTestData.to}/subdir/foo").should be_true
+        File.exist?("#{OutputTestData.to}/subdir/foo/hello.txt").should be_true
+        File.exist?("#{OutputTestData.to}/subdir/foo/test.txt").should be_false
+      end
+    end
+end

--- a/spec/output_spec.rb
+++ b/spec/output_spec.rb
@@ -97,4 +97,20 @@ describe Output, 'when having a from and to set' do
         File.exist?("#{OutputTestData.to}/subdir/foo/test.txt").should be_false
       end
     end
+    
+    describe 'and when using erb, should have templated output' do
+      before :each do
+        subdir = "#{OutputTestData.from}/subdir/foo"
+        FileUtils.mkdir_p(subdir) unless File.exists? subdir
+        File.open("#{OutputTestData.from}/subdir/foo/web.config.erb", "w"){|f| f.write "test_sub <%= my_value %>" }
+      end
+      
+      it "should rename and create entire path if nested deeply" do
+        @o.erb 'subdir/foo/web.config.erb', :as => 'subdir/foo/web.config', :locals => { :my_value => 'hello' }
+        @o.execute
+        
+        File.exist?("#{OutputTestData.to}/subdir/foo").should be_true
+        File.exist?("#{OutputTestData.to}/subdir/foo/web.config").should be_true
+      end
+    end
 end

--- a/spec/support/outputtestdata.rb
+++ b/spec/support/outputtestdata.rb
@@ -1,0 +1,13 @@
+class OutputTestData
+  
+  @@from = File.expand_path(File.join(File.dirname(__FILE__), 'src'))
+  @@to = File.expand_path(File.join(File.dirname(__FILE__), 'out'))
+  
+  def self.from
+    @@from
+  end
+  
+  def self.to
+    @@to
+  end
+end


### PR DESCRIPTION
Hi all,
I've added an output task.
I use it to replace 'one click publish' or a deployment project. example

```
output :deploy_prod do | o |
  o.from 'my.webservice'
  o.to 'out'

  o.file 'global.asax'
  o.file 'web.config.prod', :as => 'web.config'
  o.erb 'custom_config', :as => 'other.config', :locals => { :password=>'123456' }
  o.dir 'bin'
end
```

now zip 'out' and deploy it to server.
The point being is that i can also perform some other operations in the 'out' folder beforehand; such as erb output for configuration files, validating binaries, etc.

I also combine the process with jondot/version_bumper

let me know of any questions.
