### PR TITLE
Fixed an issue with the SqlCmd class and added 32bit on 64 bit support

### DIFF
--- a/lib/albacore/sqlcmd.rb
+++ b/lib/albacore/sqlcmd.rb
@@ -47,22 +47,18 @@ class SQLCmd
     end
     integratedParam
   end
-  
+
   def check_command
     sql2008cmdPath = File.join(ENV['SystemDrive'],'program files','microsoft sql server','100','tools','binn', 'sqlcmd.exe')
-    @command = sql2008cmdPath if File.exists?(sql2008cmdPath)
-    return true
-    
     sql2005cmdPath = File.join(ENV['SystemDrive'],'program files','microsoft sql server','90','tools','binn', 'sqlcmd.exe')
-    @command = sql2005cmdPath if File.exists?(sql2005cmdPath)
-    return true
-    
-    return true if (!@command.nil?)
-    
+    sql2008cmdPathx86 = File.join(ENV['SystemDrive'],'program files (x86)','microsoft sql server','100','tools','binn', 'sqlcmd.exe')
+    sql2005cmdPathx86 = File.join(ENV['SystemDrive'],'program files (x86)','microsoft sql server','90','tools','binn', 'sqlcmd.exe')
+    @command = [sql2008cmdPath, sql2005cmdPath, sql2008cmdPathx86, sql2005cmdPathx86].select { |p| File.exist?(p) }.first
+    return true if @command != nil
     fail_with_message 'SQLCmd.command cannot be nil.'
     return false
   end
-  
+
   def build_script_list
     @scripts.map{|s| "-i \"#{s.strip}\""}.join(" ")
   end

--- a/spec/sqlcmd_spec.rb
+++ b/spec/sqlcmd_spec.rb
@@ -147,19 +147,39 @@ describe SQLCmd, "when running with no command path specified" do
     @cmd.extend(SystemPatch)
     @cmd.extend(FailPatch)
     @cmd.disable_system = true
-    
+
     @cmd.execute
     @log_data = strio.string
+
+    @all_possible_sqlcmd_paths = []
+
+    ["program files", "program files (x86)"].each do |program_files|
+      ["90", "100"].each do |sql_version|
+        sqlcmd_path = File.join(ENV['SystemDrive'], program_files,'microsoft sql server', sql_version, 'tools','binn', 'sqlcmd.exe')
+        @all_possible_sqlcmd_paths << sqlcmd_path
+      end
+    end
   end
-  
+
   it "should find sqlcmd in the standard places or bail" do
-	$task_failed.should be_false if (File.exists?(File.join(ENV['SystemDrive'],'program files','microsoft sql server','100','tools','binn', 'sqlcmd.exe')))
-	$task_failed.should be_false if (File.exists?(File.join(ENV['SystemDrive'],'program files','microsoft sql server','90','tools','binn', 'sqlcmd.exe')))
-	$task_failed.should be_true if ((!(File.exists?(File.join(ENV['SystemDrive'],'program files','microsoft sql server','100','tools','binn', 'sqlcmd.exe')))) and (!(File.exists?(File.join(ENV['SystemDrive'],'program files','microsoft sql server','90','tools','binn', 'sqlcmd.exe')))))
-	end
-  
+    any_sqlcmd_exists = false
+
+    @all_possible_sqlcmd_paths.each do |sqlcmd_path|
+      sqlcmd_exists = File.exists?(sqlcmd_path)
+      any_sqlcmd_exists = true if sqlcmd_exists
+      $task_failed.should be_false if sqlcmd_exists
+    end
+    $task_failed.should be_true if any_sqlcmd_exists == false
+  end
+
   it "should log a failure message if it cannot find sqlcmd in the standard places" do
-    @log_data.should include('SQLCmd.command cannot be nil.') if ((!(File.exists?(File.join(ENV['SystemDrive'],'program files','microsoft sql server','100','tools','binn', 'sqlcmd.exe')))) and (!(File.exists?(File.join(ENV['SystemDrive'],'program files','microsoft sql server','90','tools','binn', 'sqlcmd.exe')))))
+    any_sqlcmd_exists = false
+
+    @all_possible_sqlcmd_paths.each do |sqlcmd_path|
+      sqlcmd_exists = File.exists?(sqlcmd_path)
+      any_sqlcmd_exists = true if File.exists?(sqlcmd_path)
+    end
+    @log_data.should include('SQLCmd.command cannot be nil.') if any_sqlcmd_exists == false
   end
 end
 


### PR DESCRIPTION
The SqlCmd class was quite weird inside the check_command method. It was just returning true after the first check for sqlcmd.exe.

Also, I added support for finding sqlcmd.exe in the x86 program files when 32 bit sql is installed on a 64 bit box.
