### PR TITLE
Added severity option to sqlcmd task

### DIFF
--- a/lib/albacore/sqlcmd.rb
+++ b/lib/albacore/sqlcmd.rb
@@ -4,7 +4,7 @@ class SQLCmd
   include Albacore::Task
   include Albacore::RunCommand
   
-  attr_accessor :server, :database, :username, :password, :trusted_connection, :batch_abort
+  attr_accessor :server, :database, :username, :password, :trusted_connection, :batch_abort, :severity
   attr_array :scripts
   attr_hash :variables
   
@@ -14,6 +14,7 @@ class SQLCmd
     @variables={}
     @trusted_connection = true
     @batch_abort = true
+    @severity = nil
     super()
     update_attributes Albacore.configuration.sqlcmd.to_hash
   end
@@ -29,6 +30,7 @@ class SQLCmd
     cmd_params << build_variable_list if @variables.length > 0
     cmd_params << get_batch_abort_param
     cmd_params << build_script_list if @scripts.length > 0
+    cmd_params << build_parameter("V", @severity) unless @severity.nil?
     
     result = run_command "SQLCmd", cmd_params.join(" ")
     

--- a/spec/sqlcmd_spec.rb
+++ b/spec/sqlcmd_spec.rb
@@ -312,3 +312,23 @@ describe SQLCmd, "when providing configuration" do
     sqlcmd.command.should == "configured"
   end
 end
+
+describe SQLCmd, "when severity it set" do
+  before :all do
+    @cmd = SQLCmd.new
+    @cmd.extend(SystemPatch)
+    @cmd.disable_system = true
+    @cmd.scripts "somescript.sql"
+
+    @cmd.severity = 1
+    
+    @cmd.execute
+  end
+
+  it "should have severity option set" do
+    @cmd.system_command.should include("-V")
+  end
+  it "should have severity set to correct file" do
+    @cmd.system_command.should include("-V \"1\"")
+  end
+end    

--- a/spec/sqlcmd_spec.rb
+++ b/spec/sqlcmd_spec.rb
@@ -328,7 +328,7 @@ describe SQLCmd, "when severity it set" do
   it "should have severity option set" do
     @cmd.system_command.should include("-V")
   end
-  it "should have severity set to correct file" do
+  it "should have severity set to correct value" do
     @cmd.system_command.should include("-V \"1\"")
   end
 end    


### PR DESCRIPTION
By adding a severity option to the sqlcmd task to fail if one of the provided sql scripts fails.  This allows us to run sql unit tests using albacore as it make the rake operation fail when one of the sql scripts fail.
