### PR TITLE
Added loggermodule property to msbuild.

### DIFF
--- a/lib/albacore/msbuild.rb
+++ b/lib/albacore/msbuild.rb
@@ -6,7 +6,7 @@ class MSBuild
   include Albacore::RunCommand
   include Configuration::MSBuild
   
-  attr_accessor :solution, :verbosity
+  attr_accessor :solution, :verbosity, :loggermodule
   attr_array :targets
   attr_hash :properties
   
@@ -25,6 +25,7 @@ class MSBuild
     command_parameters = []
     command_parameters << "\"#{solution}\""
     command_parameters << "\"/verbosity:#{@verbosity}\"" if @verbosity != nil
+    command_parameters << "\"/logger:#{@loggermodule}\"" if @loggermodule != nil
     command_parameters << build_properties if @properties != nil
     command_parameters << "\"/target:#{build_targets}\"" if @targets != nil
     

--- a/spec/msbuild_spec.rb
+++ b/spec/msbuild_spec.rb
@@ -9,7 +9,7 @@ shared_examples_for "prepping msbuild" do
     @msbuild = @testdata.msbuild
     @strio = StringIO.new
     @msbuild.log_device = @strio
-    @msbuild.log_level = :verbose
+    @msbuild.log_level = :diagnostic
  end
 end
 
@@ -194,3 +194,22 @@ describe MSBuild, "when specifying multiple configuration properties" do
     File.exist?(@testdata.output_path).should == true
   end
 end
+
+describe MSBuild, "when specifying a loggermodule" do  
+  it_should_behave_like "prepping msbuild"
+  
+  before :all do
+    @msbuild.solution = @testdata.solution_path
+    @msbuild.loggermodule = "FileLogger,Microsoft.Build.Engine;logfile=MyLog.log"
+    @msbuild.execute
+    
+    @log_data = @strio.string
+  end
+
+  it "should log the msbuild logger being used" do
+    puts @msbuild.system_command
+    @msbuild.system_command.should include("/logger:FileLogger,Microsoft.Build.Engine;logfile=MyLog.log")
+  end
+end
+
+


### PR DESCRIPTION
A small patch to allow for a logger module to be specified for msbuild.  For example, the TeamCity logger so that compilation failures can be reported without trawling the full logs.

http://stackoverflow.com/questions/1883753/how-to-get-teamcity-to-recognize-msbuild-compilation-errors-using-the-rake-runne
