### PR TITLE
Title attribute for nuspec generation

### DIFF
--- a/lib/albacore/nuspec.rb
+++ b/lib/albacore/nuspec.rb
@@ -31,7 +31,7 @@ end
 class Nuspec
   include Albacore::Task
   
-  attr_accessor :id, :version, :authors, :description, :language, :licenseUrl, :projectUrl, :output_file,
+  attr_accessor :id, :version, :title, :authors, :description, :language, :licenseUrl, :projectUrl, :output_file,
                 :owners, :summary, :iconUrl, :requireLicenseAcceptance, :tags, :working_directory
 				
   def initialize()
@@ -79,6 +79,7 @@ class Nuspec
     
     metadata.add_element('id').add_text(@id)
     metadata.add_element('version').add_text(@version)
+    metadata.add_element('title').add_text(@title)
     metadata.add_element('authors').add_text(@authors)
     metadata.add_element('description').add_text(@description)
     metadata.add_element('language').add_text(@language) if !@language.nil?

--- a/spec/nuspec_spec.rb
+++ b/spec/nuspec_spec.rb
@@ -50,6 +50,7 @@ describe Nuspec do
       nuspec = Nuspec.new
       nuspec.id="nuspec_test"
       nuspec.output_file = "nuspec_test.nuspec"
+      nuspec.title = "Title"
       nuspec.version = "1.2.3"
       nuspec.authors = "Author Name"
       nuspec.description = "test_xml_document"


### PR DESCRIPTION
Added the missing (not required, but kind of necessary) title attribute for nuspec generation. Without it, you don't get a very friendly name on the gallery.

I can't verify the specs still pass, as my environment is hosed at the moment. Verified it works though, as the FNH package was generated with it.
