### PR TITLE
To avoid 'csc', 'nuget' and 'aspnetcompiller' configurations from using the same config object

### DIFF
--- a/lib/albacore/config/aspnetcompilerconfig.rb
+++ b/lib/albacore/config/aspnetcompilerconfig.rb
@@ -12,9 +12,9 @@ module Configuration
     end
 
     def aspnetcompiler
-      @config ||= AspNetCompiler.aspnetcompilerconfig
-      yield(@config) if block_given?
-      @config
+      config ||= AspNetCompiler.aspnetcompilerconfig
+      yield(config) if block_given?
+      config
     end
 
     def self.included(mod)

--- a/lib/albacore/config/cscconfig.rb
+++ b/lib/albacore/config/cscconfig.rb
@@ -12,9 +12,9 @@ module Configuration
     end
 
     def csc
-      @config ||= CSC.cscconfig
-      yield(@config) if block_given?
-      @config
+      config ||= CSC.cscconfig
+      yield(config) if block_given?
+      config
     end
 
     def self.included(mod)

--- a/lib/albacore/config/nugetpackconfig.rb
+++ b/lib/albacore/config/nugetpackconfig.rb
@@ -10,9 +10,9 @@ module Configuration
     end
 
     def nugetpack
-      @config ||= NuGetPack.nugetpackconfig
-      yield(@config) if block_given?
-      @config
+      config ||= NuGetPack.nugetpackconfig
+      yield(config) if block_given?
+      config
     end
     
   end


### PR DESCRIPTION
With the current implementation single config hash is used for all of these three tasks. That could lead to a problems when you are making configurations for two or three of them in your rake script.
