### PR TITLE
Add to 'csc' task attributes for a strong name signing.

### DIFF
--- a/lib/albacore/config/aspnetcompilerconfig.rb
+++ b/lib/albacore/config/aspnetcompilerconfig.rb
@@ -12,9 +12,9 @@ module Configuration
     end
 
     def aspnetcompiler
-      @config ||= AspNetCompiler.aspnetcompilerconfig
-      yield(@config) if block_given?
-      @config
+      config ||= AspNetCompiler.aspnetcompilerconfig
+      yield(config) if block_given?
+      config
     end
 
     def self.included(mod)

--- a/lib/albacore/config/cscconfig.rb
+++ b/lib/albacore/config/cscconfig.rb
@@ -12,9 +12,9 @@ module Configuration
     end
 
     def csc
-      @config ||= CSC.cscconfig
-      yield(@config) if block_given?
-      @config
+      config ||= CSC.cscconfig
+      yield(config) if block_given?
+      config
     end
 
     def self.included(mod)

--- a/lib/albacore/config/nugetpackconfig.rb
+++ b/lib/albacore/config/nugetpackconfig.rb
@@ -10,9 +10,9 @@ module Configuration
     end
 
     def nugetpack
-      @config ||= NuGetPack.nugetpackconfig
-      yield(@config) if block_given?
-      @config
+      config ||= NuGetPack.nugetpackconfig
+      yield(config) if block_given?
+      config
     end
     
   end

--- a/lib/albacore/csc.rb
+++ b/lib/albacore/csc.rb
@@ -8,7 +8,8 @@ class CSC
   include Configuration::CSC
   include SupportsLinuxEnvironment
 
-  attr_accessor :output, :target, :optimize, :debug, :doc, :main
+  attr_accessor :output, :target, :optimize, :debug, :doc, :main,
+    :keyfile, :keycontainer, :delaysign # strong name flags
   attr_array :compile, :references, :resources, :define
 
   def initialize
@@ -25,6 +26,9 @@ class CSC
     params << "\"/out:#{@output}\"" unless @output.nil?
     params << "/target:#{@target}" unless @target.nil?
     params << "/optimize+" if @optimize
+    params << "\"/keyfile:#{@keyfile}\"" unless @keyfile.nil?
+    params << "\"/keycontainer:#{@keycontainer}\"" unless @keycontainer.nil?
+    params << "/delaysign+" if @delaysign
     params << get_debug_param unless @debug.nil?
     params << "/doc:#{@doc}" unless @doc.nil?
     params << get_define_params unless @define.nil?


### PR DESCRIPTION
It could be useful when the resulting assemblies should be signed or delay-signed.
