### PR TITLE
Nuget push and publish task.

### DIFF
--- a/lib/albacore/config/nugetpublishconfig.rb
+++ b/lib/albacore/config/nugetpublishconfig.rb
@@ -1,0 +1,19 @@
+require 'ostruct'
+require 'albacore/support/openstruct'
+
+module Configuration
+  module NuGetPublish
+    include Albacore::Configuration
+
+    def self.nugetpublishconfig
+      @config ||= OpenStruct.new.extend(OpenStructToHash).extend(NuGetPublish)
+    end
+
+    def nugetpublish
+      @config ||= NuGetPublish.nugetpublishconfig
+      yield(@config) if block_given?
+      @config
+    end
+    
+  end
+end

--- a/lib/albacore/config/nugetpushconfig.rb
+++ b/lib/albacore/config/nugetpushconfig.rb
@@ -1,0 +1,19 @@
+require 'ostruct'
+require 'albacore/support/openstruct'
+
+module Configuration
+  module NuGetPush
+    include Albacore::Configuration
+
+    def self.nugetpushconfig
+      @config ||= OpenStruct.new.extend(OpenStructToHash).extend(NuGetPush)
+    end
+
+    def nugetpush
+      @config ||= NuGetPush.nugetpushconfig
+      yield(@config) if block_given?
+      @config
+    end
+    
+  end
+end

--- a/lib/albacore/nugetpublish.rb
+++ b/lib/albacore/nugetpublish.rb
@@ -1,0 +1,47 @@
+require 'albacore/albacoretask'
+require 'albacore/config/nugetpublishconfig'
+require 'albacore/support/supportlinux'
+
+class NuGetPublish
+  include Albacore::Task
+  include Albacore::RunCommand
+  include Configuration::NuGetPublish
+  include SupportsLinuxEnvironment
+  
+  attr_accessor  :id,           # Package Id
+                 :version,      # Package Version
+                 :apikey,
+                 :source,
+                 :command
+
+  def initialize(command = "NuGet.exe") # users might have put the NuGet.exe in path
+    super()
+    update_attributes nugetpublish.to_hash
+    @command = command
+  end
+
+  def execute
+  
+    fail_with_message 'id must be specified.' if @id.nil?
+    fail_with_message 'version must be specified.' if @version.nil?
+    # don't validate @apikey as required, coz it might have been set in the config file using 'SetApiKey'
+    
+    puts @create_only
+    params = []
+    params << "publish"
+    params << "#{@id}"
+    params << "#{@version}"
+    params << "#{@apikey}" if @apikey
+    params << "-Source #{source}" unless @source.nil?
+    
+    merged_params = params.join(' ')
+    
+    @logger.debug "Build NuGet publish Command Line: #{merged_params}"
+
+    result = run_command "NuGet", merged_params
+    
+    failure_message = 'NuGet Publish Failed. See Build Log For Details'
+    fail_with_message failure_message if !result
+  end
+  
+end

--- a/lib/albacore/nugetpush.rb
+++ b/lib/albacore/nugetpush.rb
@@ -1,0 +1,46 @@
+require 'albacore/albacoretask'
+require 'albacore/config/nugetpushconfig'
+require 'albacore/support/supportlinux'
+
+class NuGetPush
+  include Albacore::Task
+  include Albacore::RunCommand
+  include Configuration::NuGetPush
+  include SupportsLinuxEnvironment
+  
+  attr_accessor  :package,
+                 :apikey,
+                 :create_only,
+                 :source,
+                 :command
+
+  def initialize(command = "NuGet.exe") # users might have put the NuGet.exe in path
+    super()
+    @create_only = false
+    update_attributes nugetpush.to_hash
+    @command = command
+  end
+
+  def execute
+  
+    fail_with_message 'package must be specified.' if @package.nil?
+    # don't validate @apikey as required, coz it might have been set in the config file using 'SetApiKey'
+    
+    params = []
+    params << "push"
+    params << "\"#{@package}\""
+    params << "#{@apikey}" if @apikey
+    params << "-CreateOnly" if @create_only
+    params << "-Source #{source}" unless @source.nil?
+    
+    merged_params = params.join(' ')
+    
+    @logger.debug "Build NuGet push Command Line: #{merged_params}"
+
+    result = run_command "NuGet", merged_params
+    
+    failure_message = 'NuGet push Failed. See Build Log For Details'
+    fail_with_message failure_message if !result
+  end
+  
+end


### PR DESCRIPTION
This includes to additional tasks called "nugetpublish" and "nugetpush". 

```
nugetpush :nuget_push do |nuget|
    nuget.command = "nuget.exe"
    nuget.package = "Facebook.5.0.25.0.nupkg"
    nuget.apikey = "...."
    nuget.source = "http://nuget.gw.symbolsource.org/Public/Nuget"
    nuget.create_only = false
end
```

command, apikey, source and create_only are optional.

if create_only is true, it uploads the package to the gallery but doesn't publish it to the live feed yet.
You will need to then use "nugetpublish" task to make it live.

```
nugetpublish :nuget_publish do |nuget|
    nuget.command = "nuget.exe"
    nuget.id =  "Facebook"
    nuget.version = "5.0.25.0"
    nuget.apikey = "...."
    nuget.source = "http://nuget.gw.symbolsource.org/Public/Nuget"
end
```

command, apikey and source are optional.

We are using this in the Facebook C# SDK library. A working example can be seen at http://facebooksdk.codeplex.com/SourceControl/changeset/view/d4704286b5f8#rakefile.rb
