### PR TITLE
Prevent a failing of an entire rake script on an xUnit test fail.

### DIFF
--- a/lib/albacore/assemblyinfolanguages/cppcliengine.rb
+++ b/lib/albacore/assemblyinfolanguages/cppcliengine.rb
@@ -1,0 +1,17 @@
+class CppCliEngine
+  def build_attribute_re(attr_name)
+    /^\[assembly: #{attr_name}(.+)/  
+  end
+
+  def build_attribute(attr_name, attr_data)
+    attribute = "[assembly: #{attr_name}("
+    attribute << "#{attr_data.inspect}" if attr_data != nil
+    attribute << ")]"
+    
+    attribute
+  end
+
+  def build_using_statement(namespace)
+    "using namespace #{namespace.gsub(/\./, '::')};"
+  end
+end

--- a/lib/albacore/config/aspnetcompilerconfig.rb
+++ b/lib/albacore/config/aspnetcompilerconfig.rb
@@ -12,9 +12,9 @@ module Configuration
     end
 
     def aspnetcompiler
-      @config ||= AspNetCompiler.aspnetcompilerconfig
-      yield(@config) if block_given?
-      @config
+      config ||= AspNetCompiler.aspnetcompilerconfig
+      yield(config) if block_given?
+      config
     end
 
     def self.included(mod)

--- a/lib/albacore/config/cscconfig.rb
+++ b/lib/albacore/config/cscconfig.rb
@@ -12,9 +12,9 @@ module Configuration
     end
 
     def csc
-      @config ||= CSC.cscconfig
-      yield(@config) if block_given?
-      @config
+      config ||= CSC.cscconfig
+      yield(config) if block_given?
+      config
     end
 
     def self.included(mod)

--- a/lib/albacore/config/nugetpackconfig.rb
+++ b/lib/albacore/config/nugetpackconfig.rb
@@ -10,9 +10,9 @@ module Configuration
     end
 
     def nugetpack
-      @config ||= NuGetPack.nugetpackconfig
-      yield(@config) if block_given?
-      @config
+      config ||= NuGetPack.nugetpackconfig
+      yield(config) if block_given?
+      config
     end
     
   end

--- a/lib/albacore/config/vssgetconfig.rb
+++ b/lib/albacore/config/vssgetconfig.rb
@@ -1,0 +1,14 @@
+require 'ostruct'
+require 'albacore/support/openstruct'
+
+module Configuration
+  module Vss
+    include Albacore::Configuration
+
+    def vss
+      @vssconfig ||= OpenStruct.new.extend(OpenStructToHash)
+      yield(@vssconfig) if block_given?
+      @vssconfig
+    end
+  end
+end

--- a/lib/albacore/csc.rb
+++ b/lib/albacore/csc.rb
@@ -8,7 +8,8 @@ class CSC
   include Configuration::CSC
   include SupportsLinuxEnvironment
 
-  attr_accessor :output, :target, :optimize, :debug, :doc, :main
+  attr_accessor :output, :target, :optimize, :debug, :doc, :main,
+    :keyfile, :keycontainer, :delaysign # strong name flags
   attr_array :compile, :references, :resources, :define
 
   def initialize
@@ -25,6 +26,9 @@ class CSC
     params << "\"/out:#{@output}\"" unless @output.nil?
     params << "/target:#{@target}" unless @target.nil?
     params << "/optimize+" if @optimize
+    params << "\"/keyfile:#{@keyfile}\"" unless @keyfile.nil?
+    params << "\"/keycontainer:#{@keycontainer}\"" unless @keycontainer.nil?
+    params << "/delaysign+" if @delaysign
     params << get_debug_param unless @debug.nil?
     params << "/doc:#{@doc}" unless @doc.nil?
     params << get_define_params unless @define.nil?

--- a/lib/albacore/support/createtask.rb
+++ b/lib/albacore/support/createtask.rb
@@ -25,6 +25,26 @@ module Albacore
           obj.execute if obj.respond_to?(:execute)
         end
       end
+
+      def #{taskname}!(name=:#{taskname}, *args, &configblock)
+        task name, *args do |t, task_args|
+          obj = #{taskclass}.new
+          obj.load_config_by_task_name(name) if obj.respond_to?(:load_config_by_task_name)
+
+          if !configblock.nil?
+            case configblock.arity
+              when 0
+                configblock.call
+              when 1
+                configblock.call(obj)
+              when 2
+                configblock.call(obj, task_args)
+            end
+          end
+
+          obj.execute if obj.respond_to?(:execute)
+        end.invoke
+      end
     EOF
   end
 end

--- a/lib/albacore/vssget.rb
+++ b/lib/albacore/vssget.rb
@@ -1,0 +1,44 @@
+require 'albacore/albacoretask'
+
+class VssGet
+  TaskName = :vssget
+  include Albacore::Task
+  include Albacore::RunCommand
+
+  attr_accessor :repository, :project, :path, :username, :password, :recursive, :readonly, :quite
+  attr_array :options
+
+  def initialize(command=nil)
+    @options=[]
+	@quite = true
+	@readonly = true
+	@recursive = true
+    super()
+	update_attributes Albacore.configuration.vss.to_hash
+    @command = command unless command.nil?
+  end
+
+  def get_command_parameters
+    command_params = []	
+    command_params << "get"
+    command_params << @project || "$/"
+    command_params << "-Q" if @quite
+    command_params << "-R" if @recursive
+    command_params << (@readonly ? "-W-" : "-W")
+    command_params << "-Y#{@username},#{@password}" unless @username.nil?
+    command_params << "\"-GL#{@path}\"" unless @path.nil?
+    command_params << @options.join(" ") unless @options.nil?
+    command_params
+  end
+
+  def execute()
+    fail_with_message 'Repository should be provided.' if @repository.nil?
+
+    ENV["SSDIR"] = @repository
+
+    result = run_command "VssGet", get_command_parameters
+
+    failure_message = 'Visual SourceSafe Failed. See Build Log For Detail'
+    fail_with_message failure_message if !result
+  end
+end

--- a/lib/albacore/xunittestrunner.rb
+++ b/lib/albacore/xunittestrunner.rb
@@ -5,7 +5,7 @@ class XUnitTestRunner
   include Albacore::Task
   include Albacore::RunCommand
 
-  attr_accessor :html_output
+  attr_accessor :html_output, :skip_test_fail
   attr_array :options,:assembly,:assemblies
 
   def initialize(command=nil)
@@ -41,7 +41,7 @@ class XUnitTestRunner
       command_params = get_command_parameters.collect{ |p| p % File.basename(assm) }
       command_params.insert(0,assm)	
       result = run_command "XUnit", command_params.join(" ")
-      fail_with_message failure_message if !result
+      fail_with_message failure_message if !result && (!@skip_test_fail || $?.exitstatus > 1)
     end       
   end
 


### PR DESCRIPTION
I'm building a project on the TeamCity. When the project tests failing, I'm still need to deploy the project artifacts. So, there will be nice to have a flag on the xUnit task which can prevent the rake script failing on the "red" test.
What do you think? 
