### PR TITLE
Handle additional_files property of ZipTask, ensure it is an array

### DIFF
--- a/lib/albacore/zipdirectory.rb
+++ b/lib/albacore/zipdirectory.rb
@@ -97,6 +97,7 @@ class ZipDirectory
   
   def zip_additional(zipfile)
     return if @additional_files.nil?
+    @additional_files = Array.[](@additional_files) unless @additional_files.kind_of?(Array)
     @additional_files.reject{|f| reject_file(f)}.each do |file_path|
       file_name = file_path.split('/').last if @flatten_zip
       zipfile.add(file_name, file_path)

--- a/spec/zip_spec.rb
+++ b/spec/zip_spec.rb
@@ -102,3 +102,59 @@ describe ZipDirectory, "when providing configuration" do
     zip.output_file.should == "configured"
   end
 end
+
+describe ZipDirectory, 'when zipping a directory of files with additional files' do
+  describe 'and additional file is given as an array' do
+    before :each do
+      zip = ZipDirectory.new
+      zip.directories_to_zip ZipTestData.folder
+      zip.output_file = 'test.zip'
+      zip.exclusions "**/subfolder/*"
+      zip.additional_files = [File.join(File.dirname(__FILE__), 'support', 'test.yml')]
+      zip.execute
+      
+      unzip = Unzip.new
+      unzip.file = File.join(ZipTestData.folder, 'test.zip')
+      unzip.destination = ZipTestData.output_folder
+      unzip.execute
+    end
+
+    after :each do
+      FileUtils.rm_rf ZipTestData.output_folder if File.exist? ZipTestData.output_folder
+    end
+
+    it "should add additional file" do
+      File.exist?(File.join(ZipTestData.folder, "test.zip")).should be_true
+      File.exist?(File.join(ZipTestData.output_folder, 'files', 'subfolder')).should be_true
+      File.exist?(File.join(ZipTestData.output_folder, 'files', 'testfile.txt')).should be_true
+      File.exist?(File.join(ZipTestData.output_folder, 'test.yml')).should be_true
+    end
+  end
+  
+  describe 'and additional file is given as a string' do
+    before :each do
+      zip = ZipDirectory.new
+      zip.directories_to_zip ZipTestData.folder
+      zip.output_file = 'test.zip'
+      zip.exclusions "**/subfolder/*"
+      zip.additional_files = File.join(File.dirname(__FILE__), 'support', 'test.yml')
+      zip.execute
+      
+      unzip = Unzip.new
+      unzip.file = File.join(ZipTestData.folder, 'test.zip')
+      unzip.destination = ZipTestData.output_folder
+      unzip.execute
+    end
+
+    after :each do
+      FileUtils.rm_rf ZipTestData.output_folder if File.exist? ZipTestData.output_folder
+    end
+    
+    it "should add additional file" do
+      File.exist?(File.join(ZipTestData.folder, "test.zip")).should be_true
+      File.exist?(File.join(ZipTestData.output_folder, 'files', 'subfolder')).should be_true
+      File.exist?(File.join(ZipTestData.output_folder, 'files', 'testfile.txt')).should be_true
+      File.exist?(File.join(ZipTestData.output_folder, 'test.yml')).should be_true
+    end
+  end
+end


### PR DESCRIPTION
ensure that any strings passed into the ZipTask additional_files property are added to an array before being used.  closes #156

Not an elegant solution.  Please change if you don't like.  You get specs though.  :)
