### PR TITLE
Added a force option to Unzip task, new task copydir

### DIFF
--- a/lib/albacore/config/copydirconfig.rb
+++ b/lib/albacore/config/copydirconfig.rb
@@ -1,0 +1,15 @@
+require 'ostruct'
+require 'albacore/support/openstruct'
+
+module Configuration
+  module CopyDir
+    include Albacore::Configuration
+
+    def copydir
+      @copydirconfig ||= OpenStruct.new.extend(OpenStructToHash)
+      yield(@copydirconfig) if block_given?
+      @copydirconfig
+    end
+  end
+end
+

--- a/lib/albacore/copydirectory.rb
+++ b/lib/albacore/copydirectory.rb
@@ -1,5 +1,6 @@
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'FileUtils'
+require 'albacore/albacoretask'
 
 class CopyDir
 	include Albacore::Task
@@ -9,14 +10,16 @@ class CopyDir
 	def initialize
 		@exclude = []
 		@delete_dest = false
+		super()
+		update_attributes Albacore.configuration.copydir.to_hash
 	end
 	
 	def execute
 		delete_dir @dest if @delete_dest && File.directory?(@dest)
-		copydir(@src, @dest)
+		copy_dir(@src, @dest)
 	end	
 		
-	def copydir(source, destination)		
+	def copy_dir(source, destination)		
 		FileUtils.mkdir destination unless File.exists? destination
 
 		Dir.foreach(source) do |file|
@@ -27,7 +30,7 @@ class CopyDir
 			destination_file = "#{destination}/#{file}"
 			
 			if File.directory?(source_file)
-				copydir source_file, destination_file
+				copy_dir source_file, destination_file
 			else
 				FileUtils.copy source_file, destination_file
 			end

--- a/lib/albacore/copydirectory.rb
+++ b/lib/albacore/copydirectory.rb
@@ -1,0 +1,59 @@
+$LOAD_PATH.unshift(File.dirname(__FILE__))
+require 'FileUtils'
+
+class CopyDir
+	include Albacore::Task
+	
+	attr_accessor :src, :dest, :exclude, :delete_dest
+	
+	def initialize
+		@exclude = []
+		@delete_dest = false
+	end
+	
+	def execute
+		delete_dir @dest if @delete_dest && File.directory?(@dest)
+		copydir(@src, @dest)
+	end	
+		
+	def copydir(source, destination)		
+		FileUtils.mkdir destination unless File.exists? destination
+
+		Dir.foreach(source) do |file|
+			next if exclude?(@exclude, file)
+			next if file == "." || file == ".."
+			
+			source_file = "#{source}/#{file}"
+			destination_file = "#{destination}/#{file}"
+			
+			if File.directory?(source_file)
+				copydir source_file, destination_file
+			else
+				FileUtils.copy source_file, destination_file
+			end
+		end
+	end
+	
+	def exclude?(exclude_files, file)
+		exclude_files.each do |s|
+			if file.match(/#{s}/i)
+				return true
+			end
+		end
+		return false
+	end
+	
+	def delete_dir(dir)	
+		FileUtils.rm_rf dir
+		waitfor {!Dir.exists?(dir)}
+	end
+	
+	def waitfor(&block)
+		checks = 0
+		until block.call || checks >10 
+			sleep 0.5
+			checks += 1
+		end
+		raise 'waitfor timeout expired' if checks > 10
+	end
+end

--- a/lib/albacore/unzip.rb
+++ b/lib/albacore/unzip.rb
@@ -6,7 +6,7 @@ include Zip
 class Unzip
   include Albacore::Task
   
-  attr_accessor :destination, :file
+  attr_accessor :destination, :file, :force
 
   def initialize
     super()
@@ -21,7 +21,7 @@ class Unzip
         zip_f.each do |f|
            out_path = File.join(@destination, f.name)
            FileUtils.mkdir_p(File.dirname(out_path))
-           zip_f.extract(f, out_path) unless File.exist?(out_path)
+           zip_f.extract(f, out_path) {@force} unless @force == false && File.exist?(out_path)
         end
       end
   end

--- a/spec/copydirectory_spec.rb
+++ b/spec/copydirectory_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+require 'albacore/copydirectory'
+require 'copydirectorytestdata'
+
+describe CopyDir, "When asked to copy directory recursively" do
+  before :each do
+    @cdir = CopyDir.new
+    @cdir.src = CopyDirTestData.folder
+    @cdir.dest = CopyDirTestData.output_folder
+	@cdir.delete_dest = true    
+  end
+  
+  after :each do
+    FileUtils.rm_rf CopyDirTestData.output_folder if File.exist? CopyDirTestData.output_folder
+  end
+  
+  it "should copy the directory and exclude files" do	
+	@cdir.exclude = ['testfile.txt']
+	@cdir.execute
+	File.exist?(File.join(CopyDirTestData.output_folder, 'files', 'testfile.txt')).should be_false
+  end  
+  
+  it "should copy the directory" do
+	@cdir.execute
+	File.exist?(File.join(CopyDirTestData.output_folder, 'files', 'testfile.txt')).should be_true
+  end  
+end

--- a/spec/support/copy_src/files/subfolder/sub file.txt
+++ b/spec/support/copy_src/files/subfolder/sub file.txt
@@ -1,0 +1,1 @@
+this is a sub file for the zip task.

--- a/spec/support/copy_src/files/testfile.txt
+++ b/spec/support/copy_src/files/testfile.txt
@@ -1,0 +1,1 @@
+this is a test file for the zip task

--- a/spec/support/copydirectorytestdata.rb
+++ b/spec/support/copydirectorytestdata.rb
@@ -1,0 +1,13 @@
+class CopyDirTestData
+  
+  @@folder = File.expand_path(File.join(File.dirname(__FILE__), 'copy_src'))
+  @@output_folder = File.expand_path(File.join(File.dirname(__FILE__), 'copy_dest'))
+  
+  def self.folder
+    @@folder
+  end
+  
+  def self.output_folder
+    @@output_folder
+  end
+end

--- a/spec/unzip_spec.rb
+++ b/spec/unzip_spec.rb
@@ -1,15 +1,88 @@
 require 'spec_helper'
+require 'ziptestdata'
+require 'albacore/zipdirectory'
 require 'albacore/unzip'
 
 describe Unzip, "when providing configuration" do
   let :uz do
     Albacore.configure do |config|
       config.unzip.file = "configured"
+      config.unzip.force = true
     end
     uz = Unzip.new
   end
 
   it "should use the configured values" do
     uz.file.should == "configured"
+  end
+  
+  it "should set the force option to true" do
+    uz.force.should be_true
+  end
+end
+
+describe Unzip, 'when unzipping a file that already exists without force option set' do
+  before :each do
+    zip = ZipDirectory.new
+    zip.directories_to_zip ZipTestData.folder
+    zip.output_file = 'test.zip'
+    zip.execute
+    
+    unzip = Unzip.new
+    unzip.file = File.join(ZipTestData.folder, 'test.zip')
+    unzip.destination = ZipTestData.output_folder
+    unzip.execute	
+  end
+  
+  after :each do
+    FileUtils.rm_rf ZipTestData.output_folder if File.exist? ZipTestData.output_folder
+  end
+  
+  it 'should not unzip the file' do  
+	new_text = "Test file for unzip task"
+  	changed_file = File.join(ZipTestData.output_folder, 'files', 'testfile.txt')
+	File.open(changed_file, 'a') { |f| f.write(new_text) }
+	
+    unzip = Unzip.new
+    unzip.file = File.join(ZipTestData.folder, 'test.zip')
+    unzip.destination = ZipTestData.output_folder
+	unzip.force = false
+    unzip.execute	
+
+    File.exist?(changed_file).should be_true
+	File.open(changed_file).grep(/#{new_text}/).count.should be > 0
+  end
+end
+
+describe Unzip, 'when unzipping a file that already exists with force option set' do
+  before :each do
+    zip = ZipDirectory.new
+    zip.directories_to_zip ZipTestData.folder
+    zip.output_file = 'test.zip'
+    zip.execute
+    
+    unzip = Unzip.new
+    unzip.file = File.join(ZipTestData.folder, 'test.zip')
+    unzip.destination = ZipTestData.output_folder
+    unzip.execute	
+  end
+  
+  after :each do
+    FileUtils.rm_rf ZipTestData.output_folder if File.exist? ZipTestData.output_folder
+  end
+  
+  it 'should unzip the file' do
+	new_text = "Test file for unzip task"
+  	changed_file = File.join(ZipTestData.output_folder, 'files', 'testfile.txt')
+	File.open(changed_file, 'a') { |f| f.write(new_text) }
+
+    unzip = Unzip.new
+    unzip.file = File.join(ZipTestData.folder, 'test.zip')
+    unzip.destination = ZipTestData.output_folder
+	unzip.force = true
+    unzip.execute	
+
+    File.exist?(changed_file).should be_true
+	File.open(changed_file).grep(/#{new_text}/).count.should be == 0
   end
 end


### PR DESCRIPTION
Added a force option to Unzip so that you can overwrite the existing files when you unzip instead of ignoring it.

Added copydir task to copy a source directory recursively to a destination (like cp_r) with options like exclude to ignore certain directories or files, delete_dest to delete destination before copying.  This may be useful when you want to selectively copy certain files in a directory before zip task.
