### PR TITLE
Fixing nuget pack task to conform with recent nuget.exe change

### DIFF
--- a/lib/albacore/nugetpack.rb
+++ b/lib/albacore/nugetpack.rb
@@ -26,8 +26,8 @@ class NuGetPack
     params = []
     params << "pack"
     params << "#{nuspec}"
-    params << "-b #{base_folder}" unless @base_folder.nil?
-    params << "-o #{output}" unless @output.nil?
+    params << "-BasePath #{base_folder}" unless @base_folder.nil?
+    params << "-OutputDirectory #{output}" unless @output.nil?
     
     merged_params = params.join(' ')
     


### PR DESCRIPTION
Fixing nuget pack task to use BasePath and OutputDirectory install of the abbreviations due to newer versions of nuget making the previously used -b ambiguous and error throwing.
