### PR TITLE
Handle additional_files property of ZipTask, ensure it is an array

### DIFF
--- a/lib/albacore/nuspec.rb
+++ b/lib/albacore/nuspec.rb
@@ -46,7 +46,7 @@ class Nuspec
   include Albacore::Task
   
   attr_accessor :id, :version, :title, :authors, :description, :language, :licenseUrl, :projectUrl, :output_file,
-                :owners, :summary, :iconUrl, :requireLicenseAcceptance, :tags, :working_directory
+                :owners, :summary, :iconUrl, :requireLicenseAcceptance, :tags, :working_directory, :copyright
 
   def initialize()
     @dependencies = Array.new
@@ -101,6 +101,7 @@ class Nuspec
     metadata.add_element('title').add_text(@title)
     metadata.add_element('authors').add_text(@authors)
     metadata.add_element('description').add_text(@description)
+    metadata.add_element('copyright').add_text(@copyright)
     metadata.add_element('language').add_text(@language) if !@language.nil?
     metadata.add_element('licenseUrl').add_text(@licenseUrl) if !@licenseUrl.nil?
     metadata.add_element('projectUrl').add_text(@projectUrl) if !@projectUrl.nil?

--- a/lib/albacore/zipdirectory.rb
+++ b/lib/albacore/zipdirectory.rb
@@ -97,6 +97,7 @@ class ZipDirectory
   
   def zip_additional(zipfile)
     return if @additional_files.nil?
+    @additional_files = Array.[](@additional_files).flatten
     @additional_files.reject{|f| reject_file(f)}.each do |file_path|
       file_name = file_path.split('/').last if @flatten_zip
       zipfile.add(file_name, file_path)

--- a/rakefile.rb
+++ b/rakefile.rb
@@ -65,6 +65,12 @@ namespace :specs do
     t.spec_opts << @spec_opts
   end
   
+  desc "NuSpec functional specs"
+  Spec::Rake::SpecTask.new :nuspec do |t|
+    t.spec_files = FileList['spec/nuspec*_spec.rb']
+    t.spec_opts << @spec_opts
+  end
+
   desc "Zip functional specs"
   Spec::Rake::SpecTask.new :zip do |t|
     t.spec_files = FileList['spec/zip*_spec.rb']

--- a/spec/nuspec_spec.rb
+++ b/spec/nuspec_spec.rb
@@ -25,6 +25,7 @@ describe Nuspec do
       nuspec.version = "1.2.3"
       nuspec.authors = "Author Name"
       nuspec.description = "test_xml_document"
+      nuspec.copyright = "copyright 2011"
       nuspec.working_directory = working_dir
       nuspec
     end
@@ -54,6 +55,7 @@ describe Nuspec do
       nuspec.version = "1.2.3"
       nuspec.authors = "Author Name"
       nuspec.description = "test_xml_document"
+      nuspec.copyright = "copyright 2011"
       nuspec.working_directory = working_dir
       nuspec.file(dll, "lib")
       nuspec
@@ -72,7 +74,7 @@ describe Nuspec do
     end
 
     it "should contain the file and it's target" do
-      @filedata.should include("<file src='C:/dev/albacore/spec/support/nuspec/somedll.dll' target='lib'/>")
+      @filedata.should match "<file src='[a-zA-Z:\/]+\/spec\/support\/nuspec\/somedll\.dll' target='lib'\/>"
     end
   end
 end

--- a/spec/support/nuspec/nuspec.xsd
+++ b/spec/support/nuspec/nuspec.xsd
@@ -23,12 +23,14 @@
                             <xs:element name="requireLicenseAcceptance" maxOccurs="1" minOccurs="0" type="xs:boolean" />
                             <xs:element name="description" maxOccurs="1" minOccurs="1" type="xs:string" />
                             <xs:element name="summary" maxOccurs="1" minOccurs="0" type="xs:string" />
+                            <xs:element name="releaseNotes" maxOccurs="1" minOccurs="0" type="xs:string" />
+                            <xs:element name="copyright" maxOccurs="1" minOccurs="0" type="xs:string" />
                             <xs:element name="language" maxOccurs="1" minOccurs="0" type="xs:string" default="en-US" />
                             <xs:element name="tags" maxOccurs="1" minOccurs="0" type="xs:string" />
                             <xs:element name="dependencies" maxOccurs="1" minOccurs="0">
                                 <xs:complexType>
                                     <xs:sequence>
-                                        <xs:element name="dependency" minOccurs="1" maxOccurs="unbounded">
+                                        <xs:element name="dependency" minOccurs="0" maxOccurs="unbounded">
                                             <xs:complexType>
                                                 <xs:attribute name="id" type="xs:string" use="required" />
                                                 <xs:attribute name="version" type="xs:string" use="optional" />
@@ -40,7 +42,7 @@
                             <xs:element name="frameworkAssemblies" maxOccurs="1" minOccurs="0">
                                 <xs:complexType>
                                     <xs:sequence>
-                                        <xs:element name="frameworkAssembly" minOccurs="1" maxOccurs="unbounded">
+                                        <xs:element name="frameworkAssembly" minOccurs="0" maxOccurs="unbounded">
                                             <xs:complexType>
                                                 <xs:attribute name="assemblyName" type="xs:string" use="required" />
                                                 <xs:attribute name="targetFramework" type="xs:string" use="optional" />
@@ -49,16 +51,28 @@
                                     </xs:sequence>
                                 </xs:complexType>
                             </xs:element>
+                            <xs:element name="references" maxOccurs="1" minOccurs="0">
+                                <xs:complexType>
+                                    <xs:sequence>
+                                        <xs:element name="reference" minOccurs="0" maxOccurs="unbounded">
+                                            <xs:complexType>
+                                                <xs:attribute name="file" type="xs:string" use="required" />
+                                            </xs:complexType>
+                                        </xs:element>
+                                    </xs:sequence>
+                                </xs:complexType>
+                            </xs:element>
                         </xs:all>
                     </xs:complexType>
                 </xs:element>
-                <xs:element name="files" minOccurs="0" maxOccurs="1">
+                <xs:element name="files" minOccurs="0" maxOccurs="1" nillable="true">
                     <xs:complexType>
                         <xs:sequence>
-                            <xs:element name="file" minOccurs="1" maxOccurs="unbounded">
+                            <xs:element name="file" minOccurs="0" maxOccurs="unbounded">
                                 <xs:complexType>
                                     <xs:attribute name="src" use="required" type="xs:string" />
                                     <xs:attribute name="target" use="optional" type="xs:string" />
+                                    <xs:attribute name="exclude" use="optional" type="xs:string" />
                                 </xs:complexType>
                             </xs:element>
                         </xs:sequence>

--- a/spec/zip_spec.rb
+++ b/spec/zip_spec.rb
@@ -102,3 +102,59 @@ describe ZipDirectory, "when providing configuration" do
     zip.output_file.should == "configured"
   end
 end
+
+describe ZipDirectory, 'when zipping a directory of files with additional files' do
+  describe 'and additional file is given as an array' do
+    before :each do
+      zip = ZipDirectory.new
+      zip.directories_to_zip ZipTestData.folder
+      zip.output_file = 'test.zip'
+      zip.exclusions "**/subfolder/*"
+      zip.additional_files = [File.join(File.dirname(__FILE__), 'support', 'test.yml')]
+      zip.execute
+      
+      unzip = Unzip.new
+      unzip.file = File.join(ZipTestData.folder, 'test.zip')
+      unzip.destination = ZipTestData.output_folder
+      unzip.execute
+    end
+
+    after :each do
+      FileUtils.rm_rf ZipTestData.output_folder if File.exist? ZipTestData.output_folder
+    end
+
+    it "should add additional file" do
+      File.exist?(File.join(ZipTestData.folder, "test.zip")).should be_true
+      File.exist?(File.join(ZipTestData.output_folder, 'files', 'subfolder')).should be_true
+      File.exist?(File.join(ZipTestData.output_folder, 'files', 'testfile.txt')).should be_true
+      File.exist?(File.join(ZipTestData.output_folder, 'test.yml')).should be_true
+    end
+  end
+  
+  describe 'and additional file is given as a string' do
+    before :each do
+      zip = ZipDirectory.new
+      zip.directories_to_zip ZipTestData.folder
+      zip.output_file = 'test.zip'
+      zip.exclusions "**/subfolder/*"
+      zip.additional_files = File.join(File.dirname(__FILE__), 'support', 'test.yml')
+      zip.execute
+      
+      unzip = Unzip.new
+      unzip.file = File.join(ZipTestData.folder, 'test.zip')
+      unzip.destination = ZipTestData.output_folder
+      unzip.execute
+    end
+
+    after :each do
+      FileUtils.rm_rf ZipTestData.output_folder if File.exist? ZipTestData.output_folder
+    end
+    
+    it "should add additional file" do
+      File.exist?(File.join(ZipTestData.folder, "test.zip")).should be_true
+      File.exist?(File.join(ZipTestData.output_folder, 'files', 'subfolder')).should be_true
+      File.exist?(File.join(ZipTestData.output_folder, 'files', 'testfile.txt')).should be_true
+      File.exist?(File.join(ZipTestData.output_folder, 'test.yml')).should be_true
+    end
+  end
+end


### PR DESCRIPTION
This ensures that any strings passed into the ZipTask additional_files property are added to an array before being used. closes #156

this is very similar to [pull request 157](https://github.com/derickbailey/Albacore/pull/157), which I already closed in haste.  Please use this one if you like.
