### PR TITLE
fixed nugetpack cli options

### DIFF
--- a/lib/albacore/nugetpack.rb
+++ b/lib/albacore/nugetpack.rb
@@ -26,8 +26,8 @@ class NuGetPack
     params = []
     params << "pack"
     params << "#{nuspec}"
-    params << "-b #{base_folder}" unless @base_folder.nil?
-    params << "-o #{output}" unless @output.nil?
+    params << "-BasePath #{base_folder}" unless @base_folder.nil?
+    params << "-OutputDirectory #{output}" unless @output.nil?
     
     merged_params = params.join(' ')
     


### PR DESCRIPTION
I fixed the nugetpack task so that it now uses the options outlined in the nuget CLI documentation.

http://docs.nuget.org/docs/reference/command-line-reference

Specifically, -OutputDirectory instead of -o, and -BasePath instead of -b.  I was receiving an "ambiguous switch -b" error.  I assume older versions of nuget only had one -b option, but the latest documentation specifies two options that start with 'B' now.
