### PR TITLE
Added support for NuGet Update

### DIFF
--- a/lib/albacore/config/nugetupdateconfig.rb
+++ b/lib/albacore/config/nugetupdateconfig.rb
@@ -1,0 +1,19 @@
+require 'ostruct'
+require 'albacore/support/openstruct'
+
+module Configuration
+  module NuGetUpdate
+    include Albacore::Configuration
+
+    def self.nugetupdateconfig
+      @config ||= OpenStruct.new.extend(OpenStructToHash).extend(NuGetUpdate)
+    end
+
+    def nugetupdate
+      config ||= NuGetUpdate.nugetupdateconfig
+      yield(config) if block_given?
+      config
+    end
+    
+  end
+end

--- a/lib/albacore/nugetupdate.rb
+++ b/lib/albacore/nugetupdate.rb
@@ -1,0 +1,51 @@
+require 'albacore/albacoretask'
+require 'albacore/config/nugetupdateconfig'
+require 'albacore/support/supportlinux'
+
+class NuGetUpdate
+  include Albacore::Task
+  include Albacore::RunCommand
+  include Configuration::NuGetUpdate
+  include SupportsLinuxEnvironment
+  
+  attr_accessor :input_file,
+                :repository_path,
+                :safe
+  
+  attr_array    :source,
+                :id
+
+  def initialize(command = "NuGet.exe") # users might have put the NuGet.exe in path
+    super()
+    update_attributes nugetupdate.to_hash
+    @command = command
+  end
+
+  def execute
+    params = get_command_parameters
+    
+    @logger.debug "Build NuGet Update Command Line: #{params}"
+    result = run_command "NuGet", params
+    
+    fail_with_message 'NuGet Update Failed. See Build Log For Detail' unless result
+  end
+  
+  def get_command_parameters
+    fail_with_message 'An input file must be specified (packages.config|solution).' if self.input_file.nil?
+    
+    params = []
+    params << "update"
+    params << "#{self.input_file}"
+    params << "-Source #{get_array_parameter(self.source)}" unless self.source.nil?
+    params << "-Id #{get_array_parameter(self.id)}" unless self.id.nil?
+    params << "-RepositoryPath #{self.repository_path}" unless self.repository_path.nil?
+    params << "-Safe" if self.safe
+    
+    merged_params = params.join(' ')
+  end
+  
+  def get_array_parameter(arr)
+    "\"#{arr.join(';')}\""
+  end
+  
+end

--- a/rakefile.rb
+++ b/rakefile.rb
@@ -1,4 +1,5 @@
 $: << './'
+require 'psych'
 require 'lib/albacore'
 require 'version_bumper'
 
@@ -62,6 +63,12 @@ namespace :specs do
   desc "Ndepend functional specs"
   Spec::Rake::SpecTask.new :ndepend do |t|
     t.spec_files = FileList['spec/ndepend*_spec.rb']
+    t.spec_opts << @spec_opts
+  end
+
+  desc "NuGet functional specs"
+  Spec::Rake::SpecTask.new :nuget do |t|
+    t.spec_files = FileList['spec/nuget*_spec.rb']
     t.spec_opts << @spec_opts
   end
   
@@ -278,7 +285,7 @@ namespace :albacore do
 end
 
 namespace :jeweler do
-  require 'jeweler'  
+  require 'jeweler'
   Jeweler::Tasks.new do |gs|
     gs.name = "albacore"
     gs.summary = "Dolphin-Safe Rake Tasks For .NET Systems"

--- a/spec/nugetupdate_spec.rb
+++ b/spec/nugetupdate_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+require 'albacore/nugetupdate'
+require 'albacore/config/nugetupdateconfig'
+
+describe NuGetUpdate do  
+  before :each do
+    @nugetupdate = NuGetUpdate.new
+    @strio = StringIO.new
+    @nugetupdate.log_device = @strio
+    @nugetupdate.log_level = :diagnostic
+  end
+  
+  context "when no path to NuGet is specified" do
+    it "assumes NuGet is in the path" do
+      @nugetupdate.command.should == "NuGet.exe"
+    end
+  end
+
+  it "generates the correct command-line parameters" do
+    @nugetupdate.input_file = "../support/TestSolution/TestSolution.sln"
+    @nugetupdate.source = "source1", "source2"
+    @nugetupdate.id = "id1", "id2"
+    @nugetupdate.repository_path = "repopath"
+    
+    params = @nugetupdate.get_command_parameters
+    params.should include(@nugetupdate.input_file)
+    params.should include("-Source \"source1;source2\"")
+    params.should include("-Id \"id1;id2\"")
+    params.should include("-RepositoryPath repopath")
+    params.should_not include("-Self")
+    
+    @nugetupdate.safe = true
+    params = @nugetupdate.get_command_parameters
+    params.should include("-Safe")
+  end
+  
+  it "fails if no input file is supplied" do
+    @nugetupdate.extend(FailPatch)
+    @nugetupdate.get_command_parameters
+    @strio.string.should include("An input file must be specified")
+  end
+end


### PR DESCRIPTION
I added support for the NuGet Update command.  We are now using this in our organization because we distribute packages among our different groups.  Now, we can automate the action of making sure that we have the latest packages from everyone else in the company before we do a build.
