### PR TITLE
Refactor rakefile

### DIFF
--- a/lib/albacore/ilmerge.rb
+++ b/lib/albacore/ilmerge.rb
@@ -1,0 +1,31 @@
+require 'albacore/albacoretask'
+
+class IlMerge 
+	TaskName = :ilmerge
+	include Albacore::Task
+	include Albacore::RunCommand
+
+	
+end
+
+module Albacore
+
+	class IlMergeResolver
+
+		def initialize(ilmerge_path=nil)
+			@ilmerge_path ||= Albacore.configuration.ilmerge_path
+		end
+
+		def resolve
+		end
+
+	end
+
+	class ConfigData
+		
+		attr_accessor :ilmerge_path
+
+	end
+
+end
+

--- a/rakefile.rb
+++ b/rakefile.rb
@@ -130,6 +130,12 @@ namespace :specs do
     t.spec_files = FileList['spec/nchurn*_spec.rb']
     t.spec_opts << @spec_opts
   end
+    
+  desc "ILMerge unit tests"
+  Spec::Rake::SpecTask.new :ilmerge do |t|
+    t.spec_files = FileList['spec/ilmerge*_spec.rb']
+    t.spec_opts << @spec_opts
+  end
 end
 
 namespace :albacore do  

--- a/rakefile.rb
+++ b/rakefile.rb
@@ -17,125 +17,16 @@ namespace :specs do
     t.spec_opts << @spec_opts
   end
   
-  desc "CSharp compiler (csc.exe) specs" 
-  Spec::Rake::SpecTask.new :csc do |t|
-    t.spec_files = FileList['spec/csc*_spec.rb']
-    t.spec_opts << @spec_opts
-  end
+	# generate tasks for each *_spec.rb file in the root spec folder
+	FileList['spec/*_spec.rb'].each do |fname|
+		spec = $1 if /spec\/(.+)_spec\.rb/ =~ fname
+		desc "Run only #{spec} specs" 
+		Spec::Rake::SpecTask.new spec do |t|
+			t.spec_files = FileList['spec/#{spec}_spec.rb']
+			t.spec_opts << @spec_opts
+		end
+	end
 
-  desc "Assembly info functional specs"
-  Spec::Rake::SpecTask.new :assemblyinfo do |t|
-    t.spec_files = FileList['spec/assemblyinfo*_spec.rb']
-    t.spec_opts << @spec_opts
-  end
-  
-  desc "MSBuild functional specs"
-  Spec::Rake::SpecTask.new :msbuild do |t|
-    t.spec_files = FileList['spec/msbuild*_spec.rb']
-    t.spec_opts << @spec_opts
-  end
-
-  desc "SQLServer SQLCmd functional specs" 
-  Spec::Rake::SpecTask.new :sqlcmd do |t|
-    t.spec_files = FileList['spec/sqlcmd*_spec.rb']
-    t.spec_opts << @spec_opts
-  end
-  
-  desc "Nant functional specs"
-  Spec::Rake::SpecTask.new :nant do |t|
-    t.spec_files = FileList['spec/nant*_spec.rb']
-    t.spec_opts << @spec_opts
-  end
-  
-  desc "NCover Console functional specs"
-  Spec::Rake::SpecTask.new :ncoverconsole do |t|
-    t.spec_files = FileList['spec/ncoverconsole*_spec.rb']
-    t.spec_opts << @spec_opts
-  end
-  
-  desc "NCover Report functional specs"
-  Spec::Rake::SpecTask.new :ncoverreport do |t|
-    t.spec_files = FileList['spec/ncoverreport*_spec.rb']
-    t.spec_opts << @spec_opts
-  end
-
-  desc "Ndepend functional specs"
-  Spec::Rake::SpecTask.new :ndepend do |t|
-    t.spec_files = FileList['spec/ndepend*_spec.rb']
-    t.spec_opts << @spec_opts
-  end
-  
-  desc "Zip functional specs"
-  Spec::Rake::SpecTask.new :zip do |t|
-    t.spec_files = FileList['spec/zip*_spec.rb']
-    t.spec_opts << @spec_opts
-    end
-
-  desc "XUnit functional specs"
-  Spec::Rake::SpecTask.new :xunit do |t|
-    t.spec_files = FileList['spec/xunit*_spec.rb']
-    t.spec_opts << @spec_opts
-  end
-
-  desc "NUnit functional specs"
-  Spec::Rake::SpecTask.new :nunit do |t|
-    t.spec_files = FileList['spec/nunit*_spec.rb']
-    t.spec_opts << @spec_opts
-  end
-
-  desc "MSTest functional specs"
-  Spec::Rake::SpecTask.new :mstest do |t|
-    t.spec_files = FileList['spec/mstest*_spec.rb']
-    t.spec_opts << @spec_opts
-  end
-
-  desc "MSpec functional specs"
-  Spec::Rake::SpecTask.new :mspec do |t|
-    t.spec_files = FileList['spec/mspec*_spec.rb']
-    t.spec_opts << @spec_opts
-  end
-
-  desc "Exec functional specs"
-  Spec::Rake::SpecTask.new :exec do |t|
-    t.spec_files = FileList['spec/exec*_spec.rb']
-    t.spec_opts << @spec_opts
-  end
-  
-  desc "Docu functional specs"
-  Spec::Rake::SpecTask.new :docu do |t|
-    t.spec_files = FileList['spec/docu*_spec.rb']
-    t.spec_opts << @spec_opts
-  end
-
-  desc "YAML Config functional specs"
-  Spec::Rake::SpecTask.new :yamlconfig do |t|
-    t.spec_files = FileList['spec/yaml*_spec.rb']
-    t.spec_opts << @spec_opts
-  end
-
-  desc "FluenMigrator functional specs"
-  Spec::Rake::SpecTask.new :fluentmigrator do |t|
-    t.spec_files = FileList['spec/fluentmigrator*_spec.rb']
-    t.spec_opts << @spec_opts
-  end	
-  
-  desc "Output functional specs"
-  Spec::Rake::SpecTask.new :output do |t|
-    t.spec_files = FileList['spec/output*_spec.rb']
-    t.spec_opts << @spec_opts
-  end
-    
-  desc "NChurn functional specs"
-  Spec::Rake::SpecTask.new :nchurn do |t|
-    t.spec_files = FileList['spec/nchurn*_spec.rb']
-    t.spec_opts << @spec_opts
-  end
-    
-  desc "ILMerge unit tests"
-  Spec::Rake::SpecTask.new :ilmerge do |t|
-    t.spec_files = FileList['spec/ilmerge*_spec.rb']
-    t.spec_opts << @spec_opts
-  end
 end
 
 namespace :albacore do  

--- a/spec/ilmerge_spec.rb
+++ b/spec/ilmerge_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+require 'albacore/ilmerge'
+
+describe IlMerge do
+
+	context 'when setting #assemblies with empty list' do
+	end
+
+	context 'when setting #assemblies with 1 item' do
+	end
+
+	context 'when setting #assemblies with 2 items' do
+	end
+
+end
+
+describe Albacore::IlMergeResolver, "Global Albacore#configure configuration" do
+
+	describe "when Albacore::ConfigData#ilmerge_path hasn't been set" do
+
+		context "and ilmerge.exe exists in Program Files" do
+			before :all do
+				@il_path = 'C:\Program Files\Microsoft\ILMerge\ilmerge.exe'
+				set_file_exists @il_path, true
+				@me = Albacore::IlMergeResolver.new ''
+			end
+
+			subject { @me.resolve }
+			it { should be @il_path }
+		end
+
+		context "and ilmerge only exists in Program Files (x86)" do
+			before :all do
+				@il_path = 'C:\Program Files\Microsoft\ILMerge\ilmerge.exe'
+				set_file_exists @il_path, true
+				@me = Albacore::IlMergeResolver.new ''
+			end
+
+			subject { @me.resolve }
+			it { should be @il_path }
+		end
+	end
+
+	def set_file_exists(path, exists)
+			File.stub!(:exists?, path).and_return(exists)
+	end
+
+end
+


### PR DESCRIPTION
Albacore's `rakefile.rb` file is huge. I just removed ~100 lines by using a loop to generate tasks for each spec. Should be less barrier to entry for adding more tasks & specs.
