### PR TITLE
Updated support for Nuspec

### DIFF
--- a/lib/albacore/nuspec.rb
+++ b/lib/albacore/nuspec.rb
@@ -45,13 +45,23 @@ end
 class Nuspec
   include Albacore::Task
   
-  attr_accessor :id, :version, :title, :authors, :description, :language, :licenseUrl, :projectUrl, :output_file,
-                :owners, :summary, :iconUrl, :requireLicenseAcceptance, :tags, :working_directory, :copyright
+  attr_accessor :id, :version, :title, :authors, :description, :language, :license_url, :project_url, :output_file,
+                :owners, :summary, :icon_url, :require_license_acceptance, :tags, :working_directory, :copyright
+
+  # Keep these around for backwards compatibility
+  alias :licenseUrl :license_url
+  alias :licenseUrl= :license_url=
+  alias :projectUrl :project_url
+  alias :projectUrl= :project_url=
+  alias :iconUrl :icon_url
+  alias :iconUrl= :icon_url=
+  alias :requireLicenseAcceptance :require_license_acceptance
+  alias :requireLicenseAcceptance= :require_license_acceptance=
 
   def initialize()
-    @dependencies = Array.new
-    @files = Array.new
-    @frameworkAssemblies = Array.new
+    @dependencies = []
+    @files = []
+    @frameworkAssemblies = []
     super()
   end
 
@@ -74,15 +84,15 @@ class Nuspec
     check_required_field @authors, "authors" 
     check_required_field @description, "description" 
     
-    if(! @working_directory.nil?)
-      @working_output_file = File.join(@working_directory, @output_file)
-    else
+    if(@working_directory.nil?)
       @working_output_file = @output_file
+    else
+      @working_output_file = File.join(@working_directory, @output_file)
     end
 
     builder = REXML::Document.new
     build(builder)
-    output=""
+    output = ""
     builder.write(output)
 
     File.open(@working_output_file, 'w') {|f| f.write(output) }
@@ -102,14 +112,14 @@ class Nuspec
     metadata.add_element('authors').add_text(@authors)
     metadata.add_element('description').add_text(@description)
     metadata.add_element('copyright').add_text(@copyright)
-    metadata.add_element('language').add_text(@language) if !@language.nil?
-    metadata.add_element('licenseUrl').add_text(@licenseUrl) if !@licenseUrl.nil?
-    metadata.add_element('projectUrl').add_text(@projectUrl) if !@projectUrl.nil?
-    metadata.add_element('owners').add_text(@owners) if !@owners.nil?
-    metadata.add_element('summary').add_text(@summary) if !@summary.nil?
-    metadata.add_element('iconUrl').add_text(@iconUrl) if !@iconUrl.nil?
-    metadata.add_element('requireLicenseAcceptance').add_text(@requireLicenseAcceptance) if !@requireLicenseAcceptance.nil?
-    metadata.add_element('tags').add_text(@tags) if !@tags.nil?
+    metadata.add_element('language').add_text(@language) unless @language.nil?
+    metadata.add_element('licenseUrl').add_text(@license_url) unless @license_url.nil?
+    metadata.add_element('projectUrl').add_text(@project_url) unless @project_url.nil?
+    metadata.add_element('owners').add_text(@owners) unless @owners.nil?
+    metadata.add_element('summary').add_text(@summary) unless @summary.nil?
+    metadata.add_element('iconUrl').add_text(@icon_url) unless @icon_url.nil?
+    metadata.add_element('requireLicenseAcceptance').add_text(@require_license_acceptance) unless @require_license_acceptance.nil?
+    metadata.add_element('tags').add_text(@tags) unless @tags.nil?
 
     if @dependencies.length > 0
       depend = metadata.add_element('dependencies')
@@ -128,7 +138,7 @@ class Nuspec
   end
 
   def check_required_field(field, fieldname)
-    return true if !field.nil?
-    raise "Nuget: required field '#{fieldname}' is not defined"
+    raise "Nuspec: required field '#{fieldname}' is not defined" if field.nil?
+    true
   end
 end

--- a/lib/albacore/nuspec.rb
+++ b/lib/albacore/nuspec.rb
@@ -121,6 +121,8 @@ class Nuspec
     output = ""
     builder.write(output, self.pretty_formatting? ? 2 : -1)
 
+    @logger.debug "Writing #{@working_output_file}"
+
     File.open(@working_output_file, 'w') {|f| f.write(output) }
   end
 

--- a/spec/nuspec_spec.rb
+++ b/spec/nuspec_spec.rb
@@ -58,6 +58,7 @@ describe Nuspec do
       nuspec.copyright = "copyright 2011"
       nuspec.working_directory = working_dir
       nuspec.file(dll, "lib")
+      nuspec.file(dll, "lib\\net40", "*.xml")
       nuspec
     end
 
@@ -74,7 +75,11 @@ describe Nuspec do
     end
 
     it "should contain the file and it's target" do
-      @filedata.downcase().should include(("<file src='" + dll + "' target='lib'/>").downcase())
+      @filedata.downcase.should include("<file src='#{dll}' target='lib'/>".downcase)
+    end
+
+    it "should contain the file and it's target and an exclude" do
+      @filedata.should include("<file exclude='*.xml' src='#{dll}' target='lib\\net40'/>")
     end
   end
 end


### PR DESCRIPTION
These commits add support for all of the different parts of a nuspec file that are currently supported with NuGet 1.5.  Specifically, it now supports an exclude attribute on the file tag and release notes are supported.

I also added a couple of convenient optional options: pretty-printing and logging when log_level is :verbose.
