### PR TITLE
Fixed Rake:DSL include to only include if defined, and on output specs as well

### DIFF
--- a/lib/albacore/output.rb
+++ b/lib/albacore/output.rb
@@ -5,7 +5,7 @@ require 'fileutils'
 
 class OutputBuilder
   include FileUtils
-  include Rake::DSL
+  include ::Rake::DSL if defined?(::Rake::DSL)
   
   def initialize(dir_to, dir_from)
     @dir_to = dir_to

--- a/rakefile.rb
+++ b/rakefile.rb
@@ -18,128 +18,15 @@ namespace :specs do
     t.pattern = 'spec/**/*_spec.rb'
     t.rspec_opts = @rspec_opts
   end
-  #].exclude{ |f| 
-  #  f if IS_IRONRUBY && (f.include?("zip")) 
-  #}
-  
-  desc "CSharp compiler (csc.exe) specs" 
-  RSpec::Core::RakeTask.new :csc do |t|
-    t.pattern = 'spec/csc*_spec.rb'
-    t.rspec_opts = @rspec_opts
-  end
 
-  desc "Assembly info functional specs"
-  RSpec::Core::RakeTask.new :assemblyinfo do |t|
-    t.pattern = 'spec/assemblyinfo*_spec.rb'
-    t.rspec_opts = @rspec_opts
-  end
-  
-  desc "MSBuild functional specs"
-  RSpec::Core::RakeTask.new :msbuild do |t|
-    t.pattern = 'spec/msbuild*_spec.rb'
-    t.rspec_opts = @rspec_opts
-  end
-
-  desc "SQLServer SQLCmd functional specs" 
-  RSpec::Core::RakeTask.new :sqlcmd do |t|
-    t.pattern = 'spec/sqlcmd*_spec.rb'
-    t.rspec_opts = @rspec_opts
-  end
-  
-  desc "Nant functional specs"
-  RSpec::Core::RakeTask.new :nant do |t|
-    t.pattern = 'spec/nant*_spec.rb'
-    t.rspec_opts = @rspec_opts
-  end
-  
-  desc "NCover Console functional specs"
-  RSpec::Core::RakeTask.new :ncoverconsole do |t|
-    t.pattern = 'spec/ncoverconsole*_spec.rb'
-    t.rspec_opts = @rspec_opts
-  end
-  
-  desc "NCover Report functional specs"
-  RSpec::Core::RakeTask.new :ncoverreport do |t|
-    t.pattern = 'spec/ncoverreport*_spec.rb'
-    t.rspec_opts = @rspec_opts
-  end
-
-  desc "Ndepend functional specs"
-  RSpec::Core::RakeTask.new :ndepend do |t|
-    t.pattern = 'spec/ndepend*_spec.rb'
-    t.rspec_opts = @rspec_opts
-  end
-  
-  desc "NuSpec functional specs"
-  RSpec::Core::RakeTask.new :nuspec do |t|
-    t.pattern = 'spec/nuspec*_spec.rb'
-    t.rspec_opts = @rspec_opts
-  end
-
-  desc "Zip functional specs"
-  RSpec::Core::RakeTask.new :zip do |t|
-    t.pattern = 'spec/zip*_spec.rb'
-    t.rspec_opts = @rspec_opts
+  # generate tasks for each *_spec.rb file in the root spec folder
+  FileList['spec/*_spec.rb'].each do |fname|
+    spec = $1 if /spec\/(.+)_spec\.rb/ =~ fname
+    desc "Run #{spec} specs"
+    RSpec::Core::RakeTask.new spec do |t|
+      t.pattern = "spec/#{spec}*_spec.rb"
+      t.rspec_opts = @spec_opts
     end
-
-  desc "XUnit functional specs"
-  RSpec::Core::RakeTask.new :xunit do |t|
-    t.pattern = 'spec/xunit*_spec.rb'
-    t.rspec_opts = @rspec_opts
-  end
-
-  desc "NUnit functional specs"
-  RSpec::Core::RakeTask.new :nunit do |t|
-    t.pattern = 'spec/nunit*_spec.rb'
-    t.rspec_opts = @rspec_opts
-  end
-
-  desc "MSTest functional specs"
-  RSpec::Core::RakeTask.new :mstest do |t|
-    t.pattern = 'spec/mstest*_spec.rb'
-    t.rspec_opts = @rspec_opts
-  end
-
-  desc "MSpec functional specs"
-  RSpec::Core::RakeTask.new :mspec do |t|
-    t.pattern = 'spec/mspec*_spec.rb'
-    t.rspec_opts = @rspec_opts
-  end
-
-  desc "Exec functional specs"
-  RSpec::Core::RakeTask.new :exec do |t|
-    t.pattern = 'spec/exec*_spec.rb'
-    t.rspec_opts = @rspec_opts
-  end
-  
-  desc "Docu functional specs"
-  RSpec::Core::RakeTask.new :docu do |t|
-    t.pattern = 'spec/docu*_spec.rb'
-    t.rspec_opts = @rspec_opts
-  end
-
-  desc "YAML Config functional specs"
-  RSpec::Core::RakeTask.new :yamlconfig do |t|
-    t.pattern = 'spec/yaml*_spec.rb'
-    t.rspec_opts = @rspec_opts
-  end
-
-  desc "FluenMigrator functional specs"
-  RSpec::Core::RakeTask.new :fluentmigrator do |t|
-    t.pattern = 'spec/fluentmigrator*_spec.rb'
-    t.rspec_opts = @rspec_opts
-  end	
-  
-  desc "Output functional specs"
-  RSpec::Core::RakeTask.new :output do |t|
-    t.pattern = 'spec/output*_spec.rb'
-    t.rspec_opts = @rspec_opts
-  end
-    
-  desc "NChurn functional specs"
-  RSpec::Core::RakeTask.new :nchurn do |t|
-    t.pattern = 'spec/nchurn*_spec.rb'
-    t.rspec_opts = @rspec_opts
   end
 end
 

--- a/spec/output_spec.rb
+++ b/spec/output_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 require 'outputtestdata'
+include ::Rake::DSL if defined?(::Rake::DSL)
+
 describe Output, 'when having a from and to set' do 
 
       before :each do


### PR DESCRIPTION
When running albacore to contribute the warnings continue. Also rspec uses this more robust require to keep backwards compatibility.
