### PR TITLE
adding support for other msbuild switches. fixes #197.

### DIFF
--- a/lib/albacore/msbuild.rb
+++ b/lib/albacore/msbuild.rb
@@ -8,7 +8,7 @@ class MSBuild
   
   attr_accessor :solution, :verbosity, :loggermodule
   attr_array :targets
-  attr_hash :properties
+  attr_hash :properties, :other_switches
   
   def initialize
     super()
@@ -27,6 +27,7 @@ class MSBuild
     command_parameters << "\"/verbosity:#{@verbosity}\"" if @verbosity != nil
     command_parameters << "\"/logger:#{@loggermodule}\"" if @loggermodule != nil
     command_parameters << build_properties if @properties != nil
+    command_parameters << build_switches if @other_switches != nil
     command_parameters << "\"/target:#{build_targets}\"" if @targets != nil
     
     result = run_command "MSBuild", command_parameters.join(" ")
@@ -51,5 +52,21 @@ class MSBuild
       option_text << "/p:#{key}\=\"#{value}\""
     end
     option_text.join(" ")
+  end
+                                        
+  def build_switches
+    switch_text = []
+    @other_switches.each do |key, value|
+        switch_text << print_switch(key, value)
+    end
+    switch_text.join(" ")
+  end
+  
+  def print_switch(key, value)
+    pure_switch?(value) ? "/#{key}" : "/#{key}:#{value}"
+  end
+  
+  def pure_switch?(value)
+    value.is_a?(TrueClass) || value == :true
   end
 end

--- a/spec/msbuild_spec.rb
+++ b/spec/msbuild_spec.rb
@@ -141,6 +141,25 @@ describe MSBuild, "when building a visual studio solution for a specified config
   end
 end
 
+describe MSBuild, "when specifying interesting switches" do
+  before :all do
+    @testdata= MSBuildTestData.new("Release")
+    @msbuild = @testdata.msbuild
+    
+    @msbuild.other_switches :nologo => :true, :maxcpucount => 4
+    @msbuild.solution = @testdata.solution_path
+    @msbuild.execute
+  end
+  
+  it "should set the no logo pure switch" do
+    @msbuild.system_command.should include("/nologo")
+  end
+  
+  it "should set the max cpu count parameterized switch" do
+    @msbuild.system_command.should include("/maxcpucount:4")
+  end
+end
+
 describe MSBuild, "when specifying targets to build" do  
   it_should_behave_like "prepping msbuild"
 
@@ -211,5 +230,3 @@ describe MSBuild, "when specifying a loggermodule" do
     @msbuild.system_command.should include("/logger:FileLogger,Microsoft.Build.Engine;logfile=MyLog.log")
   end
 end
-
-


### PR DESCRIPTION
I added support for other msbuild switches. So that a hash like this

```
msb.other_switches :nologo => :true, :maxcpucount => 4
```

will get put into the command like this

```
msbuild.exe /nologo /maxcpucount:4
```

I wrote a test with two `It`s, but couldn't get my system setup to run rspec properly. I _did_ bench test these changes.
