### PR TITLE
Wrapped a module around the Logging module.

### DIFF
--- a/lib/albacore.rb
+++ b/lib/albacore.rb
@@ -1,8 +1,5 @@
 albacore_root = File.expand_path(File.dirname(__FILE__))
 $: << albacore_root
-$: << File.join(albacore_root, "albacore")
-$: << File.join(albacore_root, "albacore", 'support')
-$: << File.join(albacore_root, "albacore", 'config')
 
 IS_IRONRUBY = (defined?(RUBY_ENGINE) && RUBY_ENGINE == "ironruby")
 

--- a/lib/albacore/albacoretask.rb
+++ b/lib/albacore/albacoretask.rb
@@ -10,7 +10,7 @@ require 'albacore/config/config'
 module Albacore
   module Task
     include Failure
-    include Logging
+    include Albacore::Logging
     include YAMLConfig
     include UpdateAttributes
 

--- a/lib/albacore/support/failure.rb
+++ b/lib/albacore/support/failure.rb
@@ -1,7 +1,7 @@
 require 'albacore/support/logging'
 
 module Failure
-  include Logging
+  include Albacore::Logging
   
   def initialize
     super()

--- a/lib/albacore/support/logging.rb
+++ b/lib/albacore/support/logging.rb
@@ -1,38 +1,40 @@
 require 'logger'
 
-module Logging
-  attr_accessor :logger, :current_log_device
-  
-  def initialize
-    create_logger(STDOUT, Logger::INFO)
-    super()
-  end
-  
-  def log_device=(logdev)
-    level = @logger.level
-    create_logger(logdev, level)
-  end
-  
-  def log_level=(level)
-    @log_level = level
-    if (level == :verbose)
-      loglevel = Logger::DEBUG
-    else
-      loglevel = Logger::INFO
-    end
-    create_logger(@current_log_device, loglevel)
-  end
-
-  def log_level
-    @log_level
-  end
-  
-  def create_logger(device, level)
-    @current_log_device = device
-    @logger = Logger.new(device)
+module Albacore
+  module Logging
+    attr_accessor :logger, :current_log_device
     
-    level = Logger::DEBUG if Albacore.configure.log_level == :verbose
-    @logger.level = level
-    @log_level = :verbose if level == Logger::DEBUG
+    def initialize
+      create_logger(STDOUT, Logger::INFO)
+      super()
+    end
+    
+    def log_device=(logdev)
+      level = @logger.level
+      create_logger(logdev, level)
+    end
+    
+    def log_level=(level)
+      @log_level = level
+      if (level == :verbose)
+        loglevel = Logger::DEBUG
+      else
+        loglevel = Logger::INFO
+      end
+      create_logger(@current_log_device, loglevel)
+    end
+
+    def log_level
+      @log_level
+    end
+    
+    def create_logger(device, level)
+      @current_log_device = device
+      @logger = Logger.new(device)
+      
+      level = Logger::DEBUG if Albacore.configure.log_level == :verbose
+      @logger.level = level
+      @log_level = :verbose if level == Logger::DEBUG
+    end
   end
 end


### PR DESCRIPTION
The logging module was conflicting with the Logging gem used by other gems so this commit wraps that module with an Albacore module. I also removed the load path alterations except for the root lib folder. While wrapping helped avoid the module clash, manually adjusting the load path by adding the support sub folder was causing the Logging gem to not be loaded if Albacore was loaded first.

This replaces pull request 204.
