### PR TITLE
Normalize number of blank lines at end of AssemblyInfo output

### DIFF
--- a/lib/albacore/assemblyinfo.rb
+++ b/lib/albacore/assemblyinfo.rb
@@ -119,7 +119,12 @@ class AssemblyInfo
     
     data.concat build_footer
 
-    data.slice(0..find_last_non_empty_index(data))
+    chomp data
+  end
+
+  def chomp(ary)
+    non_empty_rindex = ary.rindex {|line| !line.empty? } || 0
+    ary.slice(0..non_empty_rindex)
   end
 
   def build_header
@@ -128,10 +133,6 @@ class AssemblyInfo
 
   def build_footer
     @lang_engine.respond_to?(:after) ? [@lang_engine.after()] : []
-  end
-
-  def find_last_non_empty_index(data)
-    data.rindex {|line| !line.empty? } || 0
   end
 
   def build_attribute(data, attr_name, attr_data)

--- a/lib/albacore/assemblyinfo.rb
+++ b/lib/albacore/assemblyinfo.rb
@@ -118,8 +118,8 @@ class AssemblyInfo
     end
     
     data.concat build_footer
-    
-    data
+
+    data.slice(0..find_last_non_empty_index(data))
   end
 
   def build_header
@@ -128,6 +128,10 @@ class AssemblyInfo
 
   def build_footer
     @lang_engine.respond_to?(:after) ? [@lang_engine.after()] : []
+  end
+
+  def find_last_non_empty_index(data)
+    data.rindex {|line| !line.empty? } || 0
   end
 
   def build_attribute(data, attr_name, attr_data)

--- a/spec/assemblyinfo_spec.rb
+++ b/spec/assemblyinfo_spec.rb
@@ -343,3 +343,23 @@ describe AssemblyInfo, "when an input file is provided" do
      subject.scan(%Q|// baz|).length.should == 1
   end
 end
+
+describe AssemblyInfo, "when an input file is provided with no attributes" do
+
+  include_context "asminfo task"
+
+  before :all do
+    @asm.company_name = nil
+    @asm.version = nil
+
+    # make it use existing file
+    @tester.use_input_file
+  end
+
+  subject { @tester.build_and_read_assemblyinfo_file @asm }
+
+  # will give a false-positive if input file has no blank lines at the bottom
+  it "should output one blank line at the bottom" do
+    subject.scan(/[^\n]\n\z/).length.should == 1
+  end
+end


### PR DESCRIPTION
This is to address issue #214, "AssemblyInfo rewrite adds additional blank line with every execution."

There may be a more efficient way to do it, but it now passes the test I wrote.

I think/hope my changes will be compatible with #213.
